### PR TITLE
fix: resolve protobufjs import errors in downstream projects

### DIFF
--- a/src/anki/anki-package.ts
+++ b/src/anki/anki-package.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Field, Root, Type } from "protobufjs";
+import * as protobuf from "protobufjs";
 import { Open } from "unzipper";
 import {
   type ConversionIssue,
@@ -1067,9 +1067,9 @@ interface MetaMessage {
 }
 
 function parseMeta(buffer: Uint8Array): MetaMessage {
-  const root = new Root();
-  const Meta = new Type("Meta").add(
-    new Field("version", 1, "int32", "required"),
+  const root = new protobuf.Root();
+  const Meta = new protobuf.Type("Meta").add(
+    new protobuf.Field("version", 1, "int32", "required"),
   );
   root.add(Meta);
 
@@ -1078,9 +1078,9 @@ function parseMeta(buffer: Uint8Array): MetaMessage {
 }
 
 function writeMeta(message: MetaMessage): Uint8Array {
-  const root = new Root();
-  const Meta = new Type("Meta").add(
-    new Field("version", 1, "int32", "required"),
+  const root = new protobuf.Root();
+  const Meta = new protobuf.Type("Meta").add(
+    new protobuf.Field("version", 1, "int32", "required"),
   );
   root.add(Meta);
 


### PR DESCRIPTION
## Summary

- Changed from named imports to namespace import (`import * as protobuf`) for protobufjs classes in `src/anki/anki-package.ts`
- Resolves "Module not found" errors when using srs-converter in downstream projects

## Problem

The previous implementation used named imports from protobufjs:
```typescript
import { Field, Root, Type } from "protobufjs";
```

This caused module resolution issues in node, as detailled in #9.

## Solution

Changed to namespace import:
```typescript
import * as protobuf from "protobufjs";
```

And updated all usage sites to use the namespace qualifier:
- `new Root()` → `new protobuf.Root()`
- `new Type()` → `new protobuf.Type()`
- `new Field()` → `new protobuf.Field()`

This provides more reliable module resolution across different build systems and bundlers for this dependency.

## Test plan

- [x] Code passes type checking
- [x] Code passes linting
- [x] Pre-commit hooks pass

Fixes #9